### PR TITLE
Implement nodesurface minimization strategy for partitioning.

### DIFF
--- a/ramba/common.py
+++ b/ramba/common.py
@@ -41,6 +41,14 @@ try:
     # number of threads per worker
     num_threads = int(os.environ.get('RAMBA_NUM_THREADS', '1'))
 
+    # number of nodes
+    import socket
+    nodename = socket.gethostname()
+    #print(nodename, rank)
+    allnodes = set(comm.allgather(nodename))
+    #if rank==0: print(allnodes)
+    num_nodes = len(allnodes)
+
     def in_driver():
         comm = MPI.COMM_WORLD
         rank = comm.Get_rank()

--- a/ramba/common.py
+++ b/ramba/common.py
@@ -41,6 +41,11 @@ try:
     # number of threads per worker
     num_threads = int(os.environ.get('RAMBA_NUM_THREADS', '1'))
 
+    def in_driver():
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        return rank==num_workers
+
 except:
     USE_MPI=False
     USE_ZMQ= int(os.environ.get("RAMBA_USE_ZMQ", "1"))!=0
@@ -442,21 +447,14 @@ if not USE_MPI:
     ray_first_init = ray_init()
     numa_zones = os.environ.get('RAMBA_NUMA_ZONES', None) # override detected numa zones
 
+    def in_driver():
+        return ray_first_init
 
 hint_ip = os.environ.get('RAMBA_IP_HINT', None)    # IP address used to hint which interface to bind queues
 
 
 def workers_per_node():
     return num_workers // num_nodes
-
-
-def in_driver():
-    if not USE_MPI:
-        return ray_first_init
-    else:
-        comm = mpi4py.MPI.COMM_WORLD
-        rank = comm.Get_rank()
-        return rank==num_workers
 
 
 if default_bcast is None:

--- a/ramba/common.py
+++ b/ramba/common.py
@@ -17,6 +17,7 @@ import numpy as np
 import functools
 import math
 import operator
+import uuid
 
 distribute_min_size = 100
 NUM_WORKERS_FOR_BCAST=100
@@ -36,6 +37,10 @@ try:
     #print ("MPI rank", rank, os.uname()[1])
     USE_ZMQ= int(os.environ.get("RAMBA_USE_ZMQ", "0"))!=0
     default_bcast = None if USE_ZMQ else "1"
+
+    # number of threads per worker
+    num_threads = int(os.environ.get('RAMBA_NUM_THREADS', '1'))
+
 except:
     USE_MPI=False
     USE_ZMQ= int(os.environ.get("RAMBA_USE_ZMQ", "1"))!=0
@@ -92,15 +97,6 @@ def dprint(level, *args):
         print(*args)
         sys.stdout.flush()
 
-if not USE_MPI: num_workers = int(os.environ.get('RAMBA_WORKERS', "4")) # number of machines
-num_threads = int(os.environ.get('RAMBA_NUM_THREADS', '1')) # number of threads per worker
-hint_ip     = os.environ.get('RAMBA_IP_HINT', None)    # IP address used to hint which interface to bind queues
-if not USE_MPI: numa_zones  = os.environ.get('RAMBA_NUMA_ZONES', None) # override detected numa zones
-
-if default_bcast is None:
-    default_bcast = "1" if num_workers>NUM_WORKERS_FOR_BCAST else "0"
-USE_BCAST= int(os.environ.get("RAMBA_USE_BCAST", default_bcast))!=0
-
 # RAMBA_BIG_DATA environment variable MUST be set to 1 if the application will use arrays
 # larger than 2**32 in size.
 ramba_big_data = int(os.environ.get('RAMBA_BIG_DATA', "0"))
@@ -133,32 +129,69 @@ def set_common_state(st):
 def compute_regular_schedule(size, divisions, dims_do_not_distribute=[]):
     divisions[:] = compute_regular_schedule_internal(num_workers, size, tuple(dims_do_not_distribute))
 
+
+def get_div_sizes(dim_len, num_div):
+    low = dim_len // num_div
+    if dim_len % num_div == 0:
+        return low, low, low, low
+
+    rem = dim_len - (low * (num_div-1))
+    if rem >= num_div:
+        main = low + 1
+        rem = dim_len - (main * (num_div-1))
+    else:
+        main = low
+    if rem == 0:
+        rem = main
+    return main, rem, max(main, rem), min(main, rem)
+
+
+def create_divisions(divisions, size, best):
+    divshape = divisions.shape
+    assert(divshape[2] == len(best))
+    num_dim = len(size)
+    main_divs = [0] * num_dim
+    for j in range(num_dim):
+        main_divs[j], _, _, _ = get_div_sizes(size[j], best[j])
+
+    index_map = list(range(num_dim))
+
+    def crsi_div(divisions, best, main_divs, index, min_worker, max_worker, size, index_map):
+        if index >= len(best):
+            return
+
+        mapped_index = index_map[index]
+        total_workers = max_worker - min_worker + 1
+        chunks_here = total_workers // best[mapped_index]
+        last = -1
+
+        dprint(3, "crsi_div:", "best", best, "main_divs", main_divs, "index", index, "min_worker", min_worker, "max_worker", max_worker, "size", size, "chunks_here", chunks_here, "total_workers", total_workers)
+        for i in range(min_worker, max_worker + 1, chunks_here):
+            num_left = size[mapped_index] - last
+            this_div = num_left // ((max_worker + 1 - i) // chunks_here)
+            for j in range(chunks_here):
+                divisions[i+j,0,mapped_index] = last + 1
+                divisions[i+j,1,mapped_index] = last + this_div
+                if divisions[i+j,1,mapped_index] > size[mapped_index]:
+                    divisions[i+j,1,mapped_index] = size[mapped_index]
+            last += this_div
+            #last += main_divs[index]
+            crsi_div(divisions, best, main_divs, index + 1, i, i + chunks_here - 1, size, index_map)
+
+    crsi_div(divisions, best, main_divs, 0, 0, divshape[0] - 1, np.array(size) - 1, index_map)
+
+
 @functools.lru_cache(maxsize=None)
-def compute_regular_schedule_internal(num_workers, size, dims_do_not_distribute, mode="surface"):
+def compute_regular_schedule_internal(num_workers, size, dims_do_not_distribute, mode="nodesurface"):
     num_dim = len(size)
     divisions = np.empty((num_workers,2,num_dim), dtype=np.int64)
     # Get the combinations of the prime factorization of the number of workers.
-    the_factors = dim_factor_dict[num_dim]
+    the_factors = get_dim_factors(num_workers, num_dim)
     best = None
     best_value = math.inf
 
     largest = [0] * num_dim
     smallest = [0] * num_dim
-
-    def get_div_sizes(dim_len, num_div):
-        low = dim_len // num_div
-        if dim_len % num_div == 0:
-            return low, low, low, low
-
-        rem = dim_len - (low * (num_div-1))
-        if rem >= num_div:
-            main = low + 1
-            rem = dim_len - (main * (num_div-1))
-        else:
-            main = low
-        if rem == 0:
-            rem = main
-        return main, rem, max(main, rem), min(main, rem)
 
     for factored in the_factors:
         not_possible = False
@@ -213,41 +246,55 @@ def compute_regular_schedule_internal(num_workers, size, dims_do_not_distribute,
             if surface_area < best_value:
                 best_value = surface_area
                 best = factored
+        elif mode == "nodesurface":
+            # Here we primarily optimize for the surface area between nodes.
+            # Only if there are ties do we look at the intra-node surface.
+
+            surface_area = 0
+            # List of the dimensions of each block on average.
+            blockSize = [size[i]/factored[i] for i in range(len(factored))]
+            create_divisions(divisions, size, factored)
+            wpn = workers_per_node()
+
+            for j in range(num_workers):
+                for i in range(num_dim):
+                    index_to_find = divisions[j, 0, :]
+                    index_to_find[i] = divisions[j, 1, i] + 1
+                    owning_worker = find_owning_worker(divisions, index_to_find)
+                    if owning_worker is not None and j // wpn != owning_worker // wpn:
+                        # Saves the average length of the block for the current dimension.
+                        temp = blockSize[i]
+                        # Ignores the current dimension so that the surface area of the
+                        # N-dimensional face (edge for 2D, face for 3D, etc.) can be calculated.
+                        blockSize[i] = 1
+                        # Adds the calculated size of piece of the block to what has been
+                        # calculated so far. At the end of the loop, the whole representation
+                        # of a block surface area will be known.
+                        surface_area += np.prod(blockSize)
+                        # Restore the length of the current dimension for future iterations.
+                        blockSize[i] = temp
+
+            # If the N-dimensional surface area of this factorization is the best
+            # thus far then remember it.
+            if surface_area < best_value:
+                best_value = surface_area
+                best = factored
 
     if mode == "surface":
         dprint(3, "Best:", best, "Smallest surface area:", best_value)
 
     assert(best is not None)
-    divshape = divisions.shape
-    assert(divshape[2] == len(best))
-    main_divs = [0] * num_dim
-    for j in range(num_dim):
-        main_divs[j], _, _, _ = get_div_sizes(size[j], best[j])
 
-    def crsi_div(divisions, best, main_divs, index, min_worker, max_worker, size):
-        if index >= len(best):
-            return
-
-        total_workers = max_worker - min_worker + 1
-        chunks_here = total_workers // best[index]
-        last = -1
-
-        dprint(3, "crsi_div:", "best", best, "main_divs", main_divs, "index", index, "min_worker", min_worker, "max_worker", max_worker, "size", size, "chunks_here", chunks_here, "total_workers", total_workers)
-        for i in range(min_worker, max_worker + 1, chunks_here):
-            num_left = size[index] - last
-            this_div = num_left // ((max_worker + 1 - i) // chunks_here)
-            for j in range(chunks_here):
-                divisions[i+j,0,index] = last + 1
-                divisions[i+j,1,index] = last + this_div
-                #divisions[i+j,1,index] = last + main_divs[index]
-                if divisions[i+j,1,index] > size[index]:
-                    divisions[i+j,1,index] = size[index]
-            last += this_div
-            #last += main_divs[index]
-            crsi_div(divisions, best, main_divs, index + 1, i, i + chunks_here - 1, size)
-
-    crsi_div(divisions, best, main_divs, 0, 0, num_workers-1, np.array(size) - 1)
+    create_divisions(divisions, size, best)
     return divisions
+
+
+def find_owning_worker(divisions, index):
+    for i in range(divisions.shape[0]):
+        if np.all(index >= divisions[i,0,:]) and np.all(index <= divisions[i,1,:]):
+            return i
+    return None
+
 
 def exps_to_factor(factors, exps):
     rest = 1
@@ -283,6 +330,24 @@ def gen_dim_factor_dict(factors, exps):
 
     return dim_factor
 
+@functools.lru_cache(maxsize=None)
+def get_prime_factors(num_workers):
+    return gen_prime_factors(num_workers)
+
+@functools.lru_cache(maxsize=None)
+def get_dim_factor_dict(num_workers):
+    num_worker_factors, num_worker_exps = get_prime_factors(num_workers)
+    dim_factor_dict = gen_dim_factor_dict(num_worker_factors, num_worker_exps)
+    return dim_factor_dict
+
+def get_dim_factors(num_workers, num_dim):
+    dfdict = get_dim_factor_dict(num_workers)
+    if num_dim not in dfdict:
+        dfdict[num_dim] = set()
+        num_worker_factors, num_worker_exps = get_prime_factors(num_workers)
+        gen_ind_factors(dfdict[num_dim], num_worker_factors, num_worker_exps, num_dim, [])
+    return dfdict[num_dim]
+
 def gen_prime_factors(n):
     factors = []
     exps = []
@@ -309,6 +374,91 @@ def gen_prime_factors(n):
 
     return factors, exps
 
-num_worker_factors, num_worker_exps = gen_prime_factors(num_workers)
-dim_factor_dict = gen_dim_factor_dict(num_worker_factors, num_worker_exps)
 
+if not USE_MPI:
+    import ray
+
+    #num_workers = int(os.environ.get('RAMBA_WORKERS', "4")) # number of machines
+    num_workers = int(os.environ.get('RAMBA_WORKERS', "-1")) # number of machines
+    # number of threads per worker
+    num_threads = int(os.environ.get('RAMBA_NUM_THREADS', '-1'))
+    num_nodes = 0
+
+    def ray_init():
+        if ray.is_initialized():
+            return False
+
+        ray_address = os.getenv("ray_address")
+        ray_redis_pass = os.getenv("ray_redis_password")
+        if ray_address==None:
+            ray_address = "auto"
+        if ray_redis_pass==None:
+            ray_redis_pass = ""
+        try:
+            ray.init(address=ray_address, _redis_password=ray_redis_pass)
+        except:
+            print("Failed to connect to existing cluster; starting local Ray")
+            ray.init(_redis_password=str(uuid.uuid4()))
+        assert ray.is_initialized() == True
+        import time
+        time.sleep(1)
+
+        global num_workers
+        global num_threads
+        global num_nodes
+
+        cores = int(ray.available_resources()['CPU'])
+        num_nodes = len(list(filter(lambda x: x.startswith("node"), ray.available_resources().keys())))
+        dprint(2, "Ray initialized;  available cores:", cores, num_nodes)
+        # Default to use all cores.
+        if num_workers == -1:
+            if num_threads == -1:
+                cores_per_node = cores // num_nodes
+                core_factors = get_dim_factors(cores_per_node, 2)
+                dprint(2, "core_factors:", core_factors)
+                closest = 0
+                for core_factor in core_factors:
+                    total_workers = core_factor[0] * num_nodes
+                    if total_workers > closest and total_workers < 50:
+                        closest = total_workers
+                        num_workers = total_workers
+                        num_threads = core_factor[1]
+            else:
+                num_workers = cores // num_threads
+        elif num_threads == -1:
+            num_threads = cores // num_workers
+        else:
+            # If user manually gave more workers than there are cores,
+            # then reduce to only use the max core count.
+            if num_workers > cores:
+                num_workers = cores
+            if num_workers * num_threads > cores:
+                print("Ramba oversubscription: {} workers times {} threads per worker exceeds the Ray cluster core count of {}".format(num_workers, num_threads, cores))
+        dprint(2, "workers:", num_workers)
+        dprint(2, "threads per worker:", num_threads)
+
+        return True
+
+    ray_first_init = ray_init()
+    numa_zones = os.environ.get('RAMBA_NUMA_ZONES', None) # override detected numa zones
+
+
+hint_ip = os.environ.get('RAMBA_IP_HINT', None)    # IP address used to hint which interface to bind queues
+
+
+def workers_per_node():
+    return num_workers // num_nodes
+
+
+def in_driver():
+    if not USE_MPI:
+        return ray_first_init
+    else:
+        comm = mpi4py.MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        return rank==num_workers
+
+
+if default_bcast is None:
+    default_bcast = "1" if num_workers>NUM_WORKERS_FOR_BCAST else "0"
+USE_BCAST= int(os.environ.get("RAMBA_USE_BCAST", default_bcast))!=0

--- a/ramba/ramba.py
+++ b/ramba/ramba.py
@@ -107,42 +107,6 @@ if not USE_MPI:
     # Import the regular Ray API excluding PYTHON_MODE, which doesn't exist.
     exec(istmt)
 
-    def ray_init():
-        if ray.is_initialized():
-            return False
-
-        ray_address = os.getenv("ray_address")
-        ray_redis_pass = os.getenv("ray_redis_password")
-        if ray_address==None:
-            ray_address = "auto"
-        if ray_redis_pass==None:
-            ray_redis_pass = ""
-        try:
-            ray.init(address=ray_address, _redis_password=ray_redis_pass)
-        except:
-            print("Failed to connect to existing cluster; starting local Ray")
-            ray.init(_redis_password=str(uuid.uuid4()))
-        assert ray.is_initialized() == True
-        import time
-        time.sleep(1)
-        cores = ray.available_resources()['CPU']
-        dprint(2, "Ray initialized;  available cores:", cores)
-        global num_workers
-        if cores < num_workers:
-            num_workers = int(cores)
-        return True
-
-    ray_first_init = ray_init()
-
-
-def in_driver():
-    if not USE_MPI:
-        return ray_first_init
-    else:
-        comm = mpi4py.MPI.COMM_WORLD
-        rank = comm.Get_rank()
-        return rank==num_workers
-
 
 class Filler:
     PER_ELEMENT = 0


### PR DESCRIPTION
1) Move some of the non-MPI code in common to the end because it now uses functions defined later in the file.
2) For Ray, use all the cores on all the nodes by default.  If you don't specify workers or threads then use the core count to compute the optimum value of the other.  If you specify neither then it creates a worker count up to 50.
3) Use ray information to extract the number of nodes.
4) Added nodesurface mode to partitioning algorithm.  This algorithm creates the divisions for each potential partition and then iterates through all the workers' index space and ask if we go to the next value in the index space for a given dimension if this is assigned to a different node and if so that adds to the surface area, which we then seek to minimize across all possible partitionings.
5) Make some of the prime factors and factor dictionaries use lru_cache.
6) Moved ray init code to common just like MPI code.